### PR TITLE
Rename repo, revert version

### DIFF
--- a/akka-operator/values.yaml
+++ b/akka-operator/values.yaml
@@ -3,11 +3,10 @@
 # Declare variables to be passed into your templates.
 
 image:
-  # FIXME: update with "production" ECR when product created
-  repository: 709825985650.dkr.ecr.us-east-1.amazonaws.com/lightbend/akka-operator
+  repository: 709825985650.dkr.ecr.us-east-1.amazonaws.com/lightbend/akka-cloud-platform
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.0.0-1-7c205d36"
+  tag: "0.4.1"
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Using `akka-cloud-platform` by default for production repo name on Marketplace.  Production product uses the same ECR as our staging product.  The staging repo is now `akka-cloud-platform-staging`.