### PR TITLE
Add sidecar container for billing in case of gcp based deployment

### DIFF
--- a/akka-operator/templates/020-clusterrole.yaml
+++ b/akka-operator/templates/020-clusterrole.yaml
@@ -142,3 +142,18 @@ rules:
       - "create"
       - "update"
       - "list"
+{{- if .Values.provider.name }}
+{{- if eq .Values.provider.name "gcp" }}
+  - apiGroups:
+      - "cloud.google.com"
+    resources:
+      - backendconfigs
+    verbs:
+      - get
+      - list
+      - create
+      - delete
+      - patch
+      - update
+{{- end }}
+{{- end }}

--- a/akka-operator/templates/040-deployment.yaml
+++ b/akka-operator/templates/040-deployment.yaml
@@ -1,3 +1,62 @@
+{{- if .Values.provider.name }}
+{{- if eq .Values.provider.name "gcp" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ubbagent-config
+data:
+  config.yaml: |
+    # The identity section contains authentication information used
+    # by the agent.
+    identities:
+    - name: gcp
+      gcp:
+        # This parameter accepts a base64-encoded JSON service
+        # account key. The value comes from the reporting secret.
+        encodedServiceAccountKey: $AGENT_ENCODED_KEY
+          
+
+    # The metrics section defines the metric that will be reported.
+    # Metric names should match verbatim the identifiers created
+    # during pricing setup.
+    metrics:
+    - name: akka_cloud_platform_cpu_time
+      type: int
+
+      # The endpoints section of a metric defines which endpoints the
+      # metric data is sent to.
+      endpoints:
+      - name: on_disk
+      - name: servicecontrol
+
+      # The aggregation section indicates that reports that the agent
+      # receives for this metric should be aggregated for a specified
+      # period of time prior to being sent to the reporting endpoint.
+      aggregation:
+        bufferSeconds: 60
+
+    # The endpoints section defines where metering data is ultimately
+    # sent. Currently supported endpoints include:
+    # * disk - some directory on the local filesystem
+    # * servicecontrol - Google Service Control
+    endpoints:
+    - name: on_disk
+      # The disk endpoint is useful for debugging, but its inclusion
+      # is not necessary in a production deployment.
+      disk:
+        reportDir: /var/lib/ubbagent/reports
+        expireSeconds: 3600
+    - name: servicecontrol
+      servicecontrol:
+        identity: gcp
+        # The service name is unique to your application and will be
+        # provided during onboarding.
+        serviceName: akka-cloud-platform.mp-lightbend-public.appspot.com
+        consumerId: $AGENT_CONSUMER_ID
+
+{{- end }}
+{{- end }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -71,6 +130,34 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+        {{- if .Values.provider.name }}
+        {{- if eq .Values.provider.name "gcp" }}
+        - name: ubbagent
+          image: "gcr.io/lightbend-public/akka-cloud-platform/ubbagent:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          env:
+          - name: AGENT_CONFIG_FILE
+            value: "/etc/ubbagent/config.yaml"
+          - name: AGENT_LOCAL_PORT
+            value: "4567"
+          - name: AGENT_ENCODED_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "{{ .Values.reportingSecret }}"
+                key: reporting-key
+          - name: AGENT_CONSUMER_ID
+            valueFrom:
+              secretKeyRef:
+                name: "{{ .Values.reportingSecret }}"
+                key: consumer-id
+          volumeMounts:
+          - name: ubbagent-config
+            mountPath: /etc/ubbagent
+      volumes:
+        - name: ubbagent-config
+          configMap:
+            name: ubbagent-config
+        {{- end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/akka-operator/values.yaml
+++ b/akka-operator/values.yaml
@@ -22,12 +22,6 @@ podAnnotations: {}
 podSecurityContext:
   fsGroup: 2000
 securityContext: {}
-# capabilities:
-#   drop:
-#   - ALL
-# readOnlyRootFilesystem: true
-# runAsNonRoot: true
-# runAsUser: 1000
 
 resources:
   limits:
@@ -38,3 +32,8 @@ resources:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+# valid values:
+# - false (default)
+# - gcp
+provider:
+  name: false


### PR DESCRIPTION
Added a sidecar container depending on whether we are doing gcp.

The following new values have been introduced in `values.yaml`:

```
defaultAWSRepository: 709825985650.dkr.ecr.us-east-1.amazonaws.com/lightbend/akka-cloud-platform
defaultGCPRepository: gcr.io/lightbend-public/akka-cloud-platform
```

These are the default repositories for AWS and GCP.

`image.repository` is now set to `false` and will get values from cli through `helm install`.

```
helm install --dry-run --debug ./akka-operator --generate-name --set-string provider.name=gcp
```

will generate the helm charts for gcp. Similarly we handle aws through such arguments.