### PR TITLE
Operator grants lease rules

### DIFF
--- a/akka-operator/templates/020-clusterrole.yaml
+++ b/akka-operator/templates/020-clusterrole.yaml
@@ -131,3 +131,14 @@ rules:
       - delete
       - patch
       - update
+  # The akka-operator must have lease rules to create Roles that grant it ("can't grant what thee don't have")
+  # The operator doesn't operate on the Leases.
+  - apiGroups:
+      - "akka.io"
+    resources:
+      - "leases"
+    verbs:
+      - "get"
+      - "create"
+      - "update"
+      - "list"


### PR DESCRIPTION
This is a blocker for https://github.com/lightbend/akka-platform-operator/pull/475

For the operator to grant certain roles to the services it creates, the operator itself must have those roles.

