### PR TITLE
Removed conditional (gcp) from cluster-role yaml

### DIFF
--- a/akka-operator/templates/020-clusterrole.yaml
+++ b/akka-operator/templates/020-clusterrole.yaml
@@ -142,8 +142,6 @@ rules:
       - "create"
       - "update"
       - "list"
-{{- if .Values.provider.name }}
-{{- if eq .Values.provider.name "gcp" }}
   - apiGroups:
       - "cloud.google.com"
     resources:
@@ -155,5 +153,3 @@ rules:
       - delete
       - patch
       - update
-{{- end }}
-{{- end }}


### PR DESCRIPTION
2 reasons why we can do this ..

* we use this helm chart for integration testing. If we don't set this `provider.name` to gcp, then the roles for `backendconfig` will not be present. But if we set it then the whole billing stuff with ubbagent etc. also becomes part of the test and it fails
* there will be no issue with aws either since the role becomes active only for the specific api group `cloud.google.com` .. if we don't have it, it remains dormant