### PR TITLE
Support pulling from a commercial registry

### DIFF
--- a/akka-operator/templates/035-commercial-credentials-secret.yaml
+++ b/akka-operator/templates/035-commercial-credentials-secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.imageCredentials.username }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: commercial-credentials
+  labels:
+    app.kubernetes.io/component: credentials
+type: "kubernetes.io/dockerconfigjson"
+data:
+  .dockerconfigjson:  {{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.imageCredentials.registry (printf "%s:%s" .Values.imageCredentials.username .Values.imageCredentials.password | b64enc) | b64enc }}
+
+{{- end }}

--- a/akka-operator/templates/035-commercial-credentials-secret.yaml
+++ b/akka-operator/templates/035-commercial-credentials-secret.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.imageCredentials.username }}
+{{- if ne .Values.lightbendSubscription.username "false" }}
+## This is based on the Helm How-To trick to create image pull secrets (https://helm.sh/docs/howto/charts_tips_and_tricks/#creating-image-pull-secrets)
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,6 +8,6 @@ metadata:
     app.kubernetes.io/component: credentials
 type: "kubernetes.io/dockerconfigjson"
 data:
-  .dockerconfigjson:  {{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.imageCredentials.registry (printf "%s:%s" .Values.imageCredentials.username .Values.imageCredentials.password | b64enc) | b64enc }}
+  .dockerconfigjson: {{ template "imagePullSubscriptionSecret" . }}
 
 {{- end }}

--- a/akka-operator/templates/040-deployment.yaml
+++ b/akka-operator/templates/040-deployment.yaml
@@ -79,13 +79,13 @@ spec:
       labels:
         {{- include "akka-operator.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       serviceAccountName: {{ include "akka-operator.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if ne .Values.lightbendSubscription.username "false" }}
+      imagePullSecrets:
+        - name: commercial-credentials
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -94,10 +94,9 @@ spec:
           #  1. lightbend commercial (picked when the user provides subscription credentials)
           #  2. GCP's (multiple alternatives)
           #  3. AWS marketplace
-          {{- if .Values.imageCredentials.username }}
-          image: "{{ .Values.imageCredentials.registry }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullSecrets:
-            - name: "commercial-credentials"
+          {{- if ne .Values.lightbendSubscription.username "false" }}
+          image: "{{ .Values.lightbendSubscription.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          ## When downloading from the Lightbend commercial registry, there has to be an imagePullSecret (see below)
           {{- else if and (eq (toString .Values.provider.name) "gcp") (eq (toString .Values.gcp.deployer) "false") }}
           image: "{{ .Values.gcp.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- else }}

--- a/akka-operator/templates/040-deployment.yaml
+++ b/akka-operator/templates/040-deployment.yaml
@@ -90,11 +90,20 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          {{- if and (eq (toString .Values.provider.name) "gcp") (eq (toString .Values.gcp.deployer) "false") }}
+          # There's several possible registries to pull the image from:
+          #  1. lightbend commercial (picked when the user provides subscription credentials)
+          #  2. GCP's (multiple alternatives)
+          #  3. AWS marketplace
+          {{- if .Values.imageCredentials.username }}
+          image: "{{ .Values.imageCredentials.registry }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullSecrets:
+            - name: "commercial-credentials"
+          {{- else if and (eq (toString .Values.provider.name) "gcp") (eq (toString .Values.gcp.deployer) "false") }}
           image: "{{ .Values.gcp.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          {{- else}}
+          {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           {{- end }}
+
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/akka-operator/templates/040-deployment.yaml
+++ b/akka-operator/templates/040-deployment.yaml
@@ -85,6 +85,11 @@ spec:
       {{- if ne .Values.lightbendSubscription.username "false" }}
       imagePullSecrets:
         - name: commercial-credentials
+      {{- else }}
+        {{- with .Values.imagePullSecrets }}
+        imagePullSecrets:
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/akka-operator/templates/_helpers.tpl
+++ b/akka-operator/templates/_helpers.tpl
@@ -62,3 +62,12 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
+
+{{/*
+Create the configjson for a secret with the lightbend commercial credentials
+*/}}
+{{- define "imagePullSubscriptionSecret" }}
+{{- if ne .Values.lightbendSubscription.username "false" }}
+{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.lightbendSubscription.registry (printf "%s:%s" .Values.lightbendSubscription.username .Values.lightbendSubscription.password | b64enc) | b64enc }}
+{{- end }}
+{{- end }}

--- a/akka-operator/values.yaml
+++ b/akka-operator/values.yaml
@@ -44,7 +44,8 @@ gcp:
   repository: gcr.io/cloud-marketplace/lightbend-public/akka-cloud-platform
   deployer: false
 # Commercial image credentials - set `username` and `password` to install as Kubernetes Secret.
-imageCredentials:
+lightbendSubscription:
   username: false
   password: false
   registry: commercial-registry.lightbend.com
+  repository: commercial-registry.lightbend.com/akka-cloud-platform

--- a/akka-operator/values.yaml
+++ b/akka-operator/values.yaml
@@ -43,3 +43,8 @@ provider:
 gcp:
   repository: gcr.io/cloud-marketplace/lightbend-public/akka-cloud-platform
   deployer: false
+# Commercial image credentials - set `username` and `password` to install as Kubernetes Secret.
+imageCredentials:
+  username: false
+  password: false
+  registry: commercial-registry.lightbend.com


### PR DESCRIPTION
Based on https://github.com/lightbend/console-charts/blob/f7fd66b406/enterprise-suite/templates/commercial-credentials.yaml and https://github.com/lightbend/console-charts/blob/f7fd66b406a072b0b25a0050a00e9e04dc4f44eb/enterprise-suite/templates/_helpers.tpl#L1

Users would then:

```
helm upgrade -i akka-operator  "./akka-operator-helm/charts/akka-operator-1.1.20.tgz" \
  --set imageCredentials.username=<username> \
  --set imageCredentials.password=<password> \
  --set image.tag=$version \
  --set resources=null \
  --set java_tool_options="-Dakka.operator.application-namespace=akka-dev -Xlog:gc -XX:InitialRAMPercentage=75 -XX:MaxRAMPercentage=75" \
  --namespace akka-dev \
  --create-namespace
```

And not bother about the registry URL.